### PR TITLE
Fix initialization failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project are documented in this file. This change log
 ## [Unreleased]
 
 ### Fixed
-- Internal: Fixed possible test failures in non-UTC timezones.
-- Internal: Fixed graceful shutdown test.
+- Fix `queue/initialize!` that fails to create MySQL tables due to index conflict.
+- Internal: Fix possible test failures in non-UTC timezones.
+- Internal: Fix graceful shutdown test.
 
 ### Changed
 - Use JVM time when querying for pending jobs instead of relying on UTC.

--- a/src/mysql_queue/core.clj
+++ b/src/mysql_queue/core.clj
@@ -304,8 +304,8 @@
 (defn initialize!
   "Create required MySQL tables if they don't exist. Returns true."
   [db-conn]
-  (queries/create-jobs! db-conn)
   (queries/create-scheduled-jobs! db-conn)
+  (queries/create-jobs! db-conn)
   true)
 
 (defn schedule-job

--- a/test/mysql_queue/core_test.clj
+++ b/test/mysql_queue/core_test.clj
@@ -17,8 +17,7 @@
 
 (defn setup-db
   [f]
-  (queries/create-scheduled-jobs! db-conn)
-  (queries/create-jobs! db-conn)
+  (initialize! db-conn)
   (f))
 
 (defn clean-up


### PR DESCRIPTION
`mysql-queue.core/initialize!` currently fails to create required MySQL tables due to index conflict. Reordering the executed queries solves the issue.

Fixes #1 
