### PR TITLE
Introduce Java 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 jdk:
   - openjdk7
   - oraclejdk7
-  - openjdk8
   - oraclejdk8
 script: "lein2 test-all"
 before_script: "echo 'CREATE DATABASE IF NOT EXISTS clj_mysql_queue;' | mysql -uroot"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ services:
 jdk:
   - openjdk7
   - oraclejdk7
+  - openjdk8
+  - oraclejdk8
 script: "lein2 test-all"
 before_script: "echo 'CREATE DATABASE IF NOT EXISTS clj_mysql_queue;' | mysql -uroot"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ All notable changes to this project are documented in this file. This change log
 
 ### Changed
 - Use JVM time when querying for pending jobs instead of relying on UTC.
+- Verify the library works properly on Java 8.
 

--- a/test/mysql_queue/core_test.clj
+++ b/test/mysql_queue/core_test.clj
@@ -7,7 +7,7 @@
             [mysql-queue.queries :as queries]))
 
 (def db-conn {:subprotocol "mysql"
-              :subname "//localhost:3306/clj_mysql_queue"
+              :subname "//localhost:3306/clj_mysql_queue?useSSL=false"
               :user "root"
               :password ""})
 


### PR DESCRIPTION
- Add Java 8 to Travis-CI config.
- Fix JDBC warnings caused by implicitly disabled TLS.
