### PR TITLE
V1.0 alpha 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: clojure
-lein: lein2
 services:
   - mysql
 jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
-script: "lein2 test-all"
+  - oraclejdk9
+script: "lein test-all"
 before_script: "echo 'CREATE DATABASE IF NOT EXISTS clj_mysql_queue;' | mysql -uroot"
+

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,14 @@
-(defproject mysql-queue "0.2.0"
+(defproject mysql-queue "1.0.0-alpha1"
   :description "A durable queue with scheduled job support that is backed by MySQL."
   :url "https://github.com/wildbit/mysql-queue"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/core.async "0.2.374"]
-                 [org.clojure/java.jdbc "0.4.2"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.3.465"]
+                 [org.clojure/java.jdbc "0.7.5"]
                  [mysql/mysql-connector-java "5.1.28"]]
   :scm {:name "git" :url "https://github.com/wildbit/mysql-queue"}
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
-  :aliases {"test-all" ["with-profile" "+1.5:+1.6:+1.7:+1.8" "test"]})
+  :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}}
+  :aliases {"test-all" ["with-profile" "+1.7:+1.8:+1.9" "test"]})

--- a/src/mysql_queue/core.clj
+++ b/src/mysql_queue/core.clj
@@ -20,7 +20,8 @@
   (stop [worker timeout-secs]))
 
 (defrecord Worker [db-conn input-chan status consumer-threads scheduler-thread recovery-thread options]
-  Stoppable (stop [this timeout-secs]
+  Stoppable
+  (stop [this timeout-secs]
     (when (= :running @status)
       (swap! status (constantly :stopped))
       (close! input-chan)

--- a/src/mysql_queue/core.clj
+++ b/src/mysql_queue/core.clj
@@ -1,13 +1,14 @@
 (ns mysql-queue.core
   "A MySQL-backed durable queue implementation with scheduled jobs support."
-  (:import (com.mysql.jdbc.exceptions.jdbc4 MySQLIntegrityConstraintViolationException))
   (:require [mysql-queue.queries :as queries]
-            [mysql-queue.utils :refer [while-let fn-options with-error-handler]]
+            [mysql-queue.utils :refer [while-let fn-options with-error-handler profile-block meter ns->ms]]
             [clojure.string :as string]
             [clojure.set :as clj-set]
             [clojure.edn :as edn]
-            [clojure.core.async :as async :refer [chan >!! >! <! <!! go go-loop thread thread-call close! timeout alts!!]]
-            [clojure.core.async.impl.protocols :as async-proto :refer [closed?]]))
+            [clojure.core.async :as async :refer [chan >!! >! <! <!! go go-loop thread thread-call close! timeout alts! alts!!]]
+            [clojure.core.async.impl.protocols :as async-proto :refer [closed?]])
+  (:import (com.mysql.jdbc.exceptions.jdbc4 MySQLIntegrityConstraintViolationException)
+           (java.util Date)))
 
 (def ultimate-job-states #{:canceled :failed :done})
 (def max-retries 5)
@@ -19,11 +20,12 @@
 (defprotocol Stoppable
   (stop [worker timeout-secs]))
 
-(defrecord Worker [db-conn input-chan status consumer-threads scheduler-thread recovery-thread options]
+(defrecord Worker
+  [db-conn input-chan status sieve status-threads consumer-threads scheduler-thread recovery-thread options]
   Stoppable
   (stop [this timeout-secs]
-    (when (= :running @status)
-      (swap! status (constantly :stopped))
+    (when (:running @status)
+      (swap! status assoc :running false)
       (close! input-chan)
       (let [consumer-shutdowns (->> consumer-threads
                                     (concat [scheduler-thread recovery-thread])
@@ -154,28 +156,32 @@
   (finished? [job]
     (ultimate-job-states (:status job)))
   (execute [{:as job job-fn :user-fn :keys [status parameters attempt]} db-conn log-fn err-fn]
-    (if-not (ultimate-job-states status)
-      (try
-        (log-fn :info job "Executing job " job)
-        (let [[status params] (-> (job-fn status parameters) job-result-or-nil (or [:done nil]))]
-          (-> job (beget status params) (persist db-conn)))
-        (catch Exception e
-          (err-fn e)
-          (if (< attempt max-retries)
-            (-> job beget (persist db-conn))
-            (-> job (beget :failed) (persist db-conn)))))
-      (cleanup job db-conn)))
+    (profile-block [m]
+      (if (finished? job)
+        (cleanup job db-conn)
+        (try
+          (log-fn :info job "Executing job " job)
+          (let [[status params] (-> (meter m :job-fn (job-fn status parameters))
+                                    job-result-or-nil (or [:done nil]))]
+            (-> job (beget status params) (persist db-conn)))
+          (catch Exception e
+            (err-fn e)
+            (if (< attempt max-retries)
+              (-> job beget (persist db-conn))
+              (-> job (beget :failed) (persist db-conn))))))))
   StuckJob
   (finished? [job] false)
   (execute [job db-conn log-fn err-fn]
-    (log-fn :info job "Recovering job " job)
-    (-> job beget (persist db-conn)))
+    (profile-block [_]
+      (log-fn :info job "Recovering job " job)
+      (-> job beget (persist db-conn))))
   ScheduledJob
   (finished? [job]
     (throw (UnsupportedOperationException. "finished? is not implemented for ScheduledJob.")))
   (execute [job db-conn log-fn _err-fn]
-    (log-fn :info job "Executing job " job)
-    (-> job beget (persist db-conn))))
+    (profile-block [_]
+      (log-fn :info job "Executing job " job)
+      (-> job beget (persist db-conn)))))
 
 (defn- get-scheduled-jobs
   "Searches for ready scheduled jobs and attempts to insert root jobs for each of those.
@@ -206,37 +212,115 @@
       total
       false)))
 
+(defn- default-status
+  "Build the default status map for a given number of consumer threads."
+  [{:keys [num-consumer-threads
+           recovery-threshold-mins
+           min-scheduler-sleep-interval
+           max-scheduler-sleep-interval
+           min-recovery-sleep-interval
+           max-recovery-sleep-interval]}]
+  {:running true
+   :consumers (mapv #(hash-map :n (inc %)
+                               :started-at (Date.)
+                               :jobs-executed 0N
+                               :recent-jobs [])
+                    (range num-consumer-threads))
+   :recovery {:started-at (Date.)
+              :min-interval min-recovery-sleep-interval
+              :max-interval max-recovery-sleep-interval
+              :iterations 0N
+              :jobs-published 0N}
+   :scheduler {:started-at (Date.)
+               :min-interval min-scheduler-sleep-interval
+               :max-interval max-scheduler-sleep-interval
+               :recovery-threshold-mins recovery-threshold-mins
+               :iterations 0N
+               :jobs-published 0N}})
+
 (defn- consumer-thread
   "Consumer loop. Automatically quits if the listen-chan is closed. Runs in a go-thread."
-  [listen-chan db-conn log-fn err-fn]
+  [id listen-chan status-chan db-conn log-fn err-fn]
   (go
     (while-let [job (<! listen-chan)]
       (try
-        (loop [job job]
-          (when job
-            (log-fn :debug job "Consumer received job " job)
-            (recur (<! (thread (execute job db-conn log-fn err-fn))))))
+        (log-fn :debug job "Consumer received job " job)
+        (loop [current-job job
+               metrics {}]
+          (if current-job
+            (do
+              (>! status-chan {:id id :state :running-job :job current-job})
+              (let [[next-job dmetrics] (<! (thread (execute current-job db-conn log-fn err-fn)))]
+                (recur next-job (merge-with + metrics dmetrics))))
+            (do
+              (>! status-chan {:id id :state :finished-job :job current-job :metrics metrics})
+              (log-fn :info current-job "Completed job " job " in " (ns->ms (:full metrics)) "ms")
+              nil)))
         (catch Exception e
+          (>! status-chan {:id id :state :error :job job})
           (log-fn :error job "Unexpected error " e " in consumer loop when running job " job)
           (err-fn e))))
+    (>! status-chan {:id id :state :quit})
     (log-fn :debug "Consumer Thread" "Consumer is stopping...")
     :done))
 
 (defn- publisher-thread
   "Publisher loop. Automatically quits if the publish-chan is closed. Runs in a go-thread."
-  [min-sleep-secs max-sleep-secs source-fn log-fn]
+  [status-chan min-sleep-secs max-sleep-secs source-fn log-fn]
   (go-loop [last-exec (System/currentTimeMillis)]
-    (if-let [num-jobs (<! (thread-call source-fn))]
+    (if-let [published (<! (thread-call source-fn))]
       (do
-        (if (zero? num-jobs)
+        (>! status-chan {:state :running :jobs-published published})
+        (if (zero? published)
           (<! (timeout (max (* 1000 min-sleep-secs)
                             (- (* 1000 max-sleep-secs)
                                (- (System/currentTimeMillis) last-exec)))))
-          (log-fn :debug nil "Published " num-jobs " new jobs."))
+          (log-fn :debug nil "Published " published " new jobs."))
         (recur (System/currentTimeMillis)))
       (do
+        (>! status-chan {:state :quit :jobs-published 0})
         (log-fn :debug nil "Publisher is stopping...")
         :done))))
+
+(defn- status-threads
+  "Status loop. Listens for status updates from consumer and publisher threads.
+   Runs multiple go-threads."
+  [status num-kept-jobs]
+  (let [consumer-chan (chan)
+        scheduler-chan (chan)
+        recovery-chan (chan)
+        consumer-fn (fn [{:keys [recent-jobs] :as status} consumer-state job metrics]
+                      (let [current-time (Date.)
+                            finished? (= consumer-state :finished-job)
+                            overflow (inc (- (count recent-jobs) num-kept-jobs))
+                            overflow? (pos? overflow)
+                            job (assoc job :metrics metrics :processed-at current-time)]
+                        (cond-> status
+                          true (assoc :last-update-at current-time
+                                      :last-job job
+                                      :state consumer-state)
+                          (and finished? overflow?) (update :recent-jobs subvec overflow)
+                          finished? (update :jobs-executed inc)
+                          finished? (update :recent-jobs conj job))))
+        consumer-thread (go
+                          (while-let [{:keys [id job state metrics]} (<! consumer-chan)]
+                            (swap! status update-in [:consumers id] consumer-fn state job metrics)))
+        publisher-fn (fn [status publisher-state jobs-published]
+                       (-> status
+                           (assoc :last-update-at (Date.)
+                                  :state publisher-state
+                                  :jobs-published-last-run jobs-published)
+                           (update :jobs-published + jobs-published)
+                           (update :iterations inc)))
+        scheduler-thread (go
+                           (while-let [{:keys [state jobs-published]} (<! scheduler-chan)]
+                             (swap! status update :scheduler publisher-fn state jobs-published)))
+        recovery-thread (go
+                          (while-let [{:keys [state jobs-published]} (<! recovery-chan)]
+                            (swap! status update :recovery publisher-fn state jobs-published)))]
+    {:consumer {:channel consumer-chan :thread consumer-thread}
+     :scheduler {:channel scheduler-chan :thread scheduler-thread}
+     :recovery {:channel recovery-chan :thread recovery-thread}}))
 
 (defn- sieve->ids
   "Returns a sieve seq that can be used to filter SQL queries for
@@ -264,13 +348,13 @@
             (>! ch v))
           (recur))
         (close! ch)))
-    (doseq [out-ch out-chs]
-      (go-loop [last-v nil]
-        (if-let [v (<! ch)]
-          (do
-            (>! out-ch v)
-            (swap! sieve disj last-v)
-            (recur v))
+    (go-loop [occupations {}]
+      (if-let [v (<! ch)]
+        (let [[v ch] (alts! (map #(vector %1 v) out-chs))]
+          (when-let [occupation (occupations ch)]
+            (swap! sieve disj occupation))
+          (recur (assoc occupations ch v)))
+        (doseq [out-ch out-chs]
           (close! out-ch))))
     [in-ch out-chs sieve]))
 
@@ -346,6 +430,7 @@
    fn-bindings
    &{:keys [buffer-size
             prefetch
+            num-stats-jobs
             num-consumer-threads
             min-scheduler-sleep-interval
             max-scheduler-sleep-interval
@@ -356,6 +441,7 @@
             err-fn]
      :or {buffer-size 10
           prefetch 10
+          num-stats-jobs 50
           num-consumer-threads 2
           min-scheduler-sleep-interval 0
           max-scheduler-sleep-interval 10
@@ -372,14 +458,32 @@
          (fn? err-fn)]}
   (let [log-fn (quiet-log-fn log-fn)
         err-fn (quiet-err-fn err-fn)
+        options {:buffer-size buffer-size
+                 :prefetch prefetch
+                 :num-stats-jobs num-stats-jobs
+                 :num-consumer-threads num-consumer-threads
+                 :min-scheduler-sleep-interval min-scheduler-sleep-interval
+                 :max-scheduler-sleep-interval max-scheduler-sleep-interval
+                 :min-recovery-sleep-interval min-recovery-sleep-interval
+                 :max-recovery-sleep-interval max-recovery-sleep-interval
+                 :recovery-threshold-mins recovery-threshold-mins
+                 :log-fn log-fn
+                 :err-fn err-fn}
+        status (atom (default-status options))
+        {:as status-threads
+         {consumer-status-channel :channel} :consumer
+         {recovery-status-channel :channel} :recovery
+         {scheduler-status-channel :channel} :scheduler} (status-threads status num-stats-jobs)
         queue-chan (chan buffer-size)
         [in-ch out-chs sieve] (deduplicate queue-chan num-consumer-threads)
         consumer-threads (->> out-chs
-                              (map #(consumer-thread % db-conn log-fn err-fn))
+                              (map-indexed
+                                #(consumer-thread %1 %2 consumer-status-channel db-conn log-fn err-fn))
                               (into [])
                               doall)
         handler (partial publisher-error-handler log-fn err-fn)
-        scheduler-thread (publisher-thread min-scheduler-sleep-interval
+        scheduler-thread (publisher-thread scheduler-status-channel
+                                           min-scheduler-sleep-interval
                                            max-scheduler-sleep-interval
                                            (with-error-handler [(handler "scheduler thread")]
                                              (batch-publish in-ch
@@ -388,7 +492,8 @@
                                                                                 fn-bindings
                                                                                 (sieve->ids @sieve ScheduledJob))))
                                            log-fn)
-        recovery-thread (publisher-thread min-recovery-sleep-interval
+        recovery-thread (publisher-thread recovery-status-channel
+                                          min-recovery-sleep-interval
                                           max-recovery-sleep-interval
                                           (with-error-handler [(handler "recovery thread")]
                                             (batch-publish in-ch
@@ -401,16 +506,11 @@
     (log-fn :info nil "Starting a new worker...")
     (->Worker db-conn
               in-ch
-              (atom :running)
+              status
+              sieve
+              status-threads
               consumer-threads
               scheduler-thread
               recovery-thread
-              {:buffer-size buffer-size
-               :prefetch prefetch
-               :num-consumer-threads num-consumer-threads
-               :min-scheduler-sleep-interval min-scheduler-sleep-interval
-               :max-scheduler-sleep-interval max-scheduler-sleep-interval
-               :recovery-threshold-mins recovery-threshold-mins
-               :log-fn log-fn
-               :err-fn err-fn})))
+              options)))
 

--- a/src/mysql_queue/utils.clj
+++ b/src/mysql_queue/utils.clj
@@ -32,6 +32,19 @@
        (catch Exception e#
          (~f e#)))))
 
+(defn numeric-stats
+  "Returns a map containing the minimum (:min), the maximum (:max),
+   the median (:median), the mean (:mean), and the 90 percentile (:90p)."
+  [s]
+  (when (seq s)
+    (let [sorted (sort s)
+          length (count s)]
+      {:min (first sorted)
+       :max (last sorted)
+       :mean (float (/ (reduce + s) length))
+       :median (nth sorted (dec (/ length 2)))
+       :90p (nth sorted (dec (/ (* 9 length) 10)))})))
+
 (defn ns->ms
   "Converts a value in nanoseconds to milliseconds."
   [t]

--- a/src/mysql_queue/utils.clj
+++ b/src/mysql_queue/utils.clj
@@ -32,3 +32,37 @@
        (catch Exception e#
          (~f e#)))))
 
+(defn ns->ms
+  "Converts a value in nanoseconds to milliseconds."
+  [t]
+  (Math/round (/ (double t) 1000000)))
+
+(defmacro profile
+  "Profiles a block of code. Returns a vector with original return value and
+   elapsed time in ns."
+  [& body]
+  `(let [start# (System/nanoTime)
+         ret# (do ~@body)
+         elapsed# (- (System/nanoTime) start#)]
+     [ret# elapsed#]))
+
+(defmacro meter
+  "Profiles a block of code. Assocs result to a named key in a provided atom.
+   Returns the original return value."
+  [metrics name & body]
+  `(let [[ret# elapsed#] (profile ~@body)]
+     (swap! ~metrics assoc ~name elapsed#)
+     ret#))
+
+(defmacro profile-block
+  "Profiles a block of code with multiple named hot spots. Requires a binding for
+   optionally used atom. Pass this atom to `meter` to register hot spots.
+   Returns a map of hotspot => execution time (in ns).
+   The entire block is wrapped in :full hotspot by default."
+  [[metrics :as bindings] & body]
+  {:pre [(= 1 (count bindings))]}
+  `(let [metrics# (atom {})
+         ~metrics metrics#
+         ret# (meter metrics# :full ~@body)]
+     [ret# (deref metrics#)]))
+

--- a/test/mysql_queue/core_test.clj
+++ b/test/mysql_queue/core_test.clj
@@ -239,7 +239,7 @@
         exception (promise)
         check-ins (check-in-atom expected-set success?)
         jobs {:test-foo (fn [status {id :id :as args}]
-                          (Thread/sleep 20)
+                          (Thread/sleep 50)
                           (swap! check-ins conj id)
                           [:done args])}]
     (with-worker [wrk (worker db-conn

--- a/test/mysql_queue/core_test.clj
+++ b/test/mysql_queue/core_test.clj
@@ -239,7 +239,7 @@
         exception (promise)
         check-ins (check-in-atom expected-set success?)
         jobs {:test-foo (fn [status {id :id :as args}]
-                          (Thread/sleep 50)
+                          (Thread/sleep 20)
                           (swap! check-ins conj id)
                           [:done args])}]
     (with-worker [wrk (worker db-conn
@@ -273,8 +273,8 @@
              :as status}
             (status wrk)]
         (is (= 1 (count consumers)))
-        (is (<= 50 (:overdue scheduled-jobs) 101))
-        (is (<= 50 (:total scheduled-jobs) 101))
+        (is (<= 1 (:overdue scheduled-jobs) 101))
+        (is (<= 1 (:total scheduled-jobs) 101))
         (is (<= 0 (:stuck jobs) 1))
         (is (<= 0 (:total jobs) 50)))
 

--- a/test/mysql_queue/utils_test.clj
+++ b/test/mysql_queue/utils_test.clj
@@ -27,3 +27,11 @@
     (is (<= 50000000 (:subop m) 60000000))
     (is (<= 100000000 (:full m)))))
 
+(deftest numeric-stats-test
+  (let [stats (numeric-stats (shuffle (range 1 101)))]
+    (is (= 1 (:min stats)))
+    (is (= 100 (:max stats)))
+    (is (= 50 (:median stats)))
+    (is (= 50.5 (:mean stats)))
+    (is (= 90 (:90p stats)))))
+

--- a/test/mysql_queue/utils_test.clj
+++ b/test/mysql_queue/utils_test.clj
@@ -1,0 +1,29 @@
+(ns mysql-queue.utils-test
+  (:require [mysql-queue.utils :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest while-let-test
+  (let [s (atom [1 2 3 4 5])]
+    (is (nil? (while-let [[x] (seq @s)] (swap! s rest))))
+    (is (empty? @s))))
+
+(deftest ns->ms-test
+  (is (= 0 (ns->ms 0)))
+  (is (= 1 (ns->ms 1000000))))
+
+(deftest profile-test
+  (let [p (promise)
+        [ret t] (profile (deref p 50 42))]
+    (is (= 42 ret))
+    (is (<= 50000000 t))))
+
+(deftest profile-block-test
+  (let [p (promise)
+        [ret m] (profile-block [m]
+                  (meter m :subop (deref p 50 nil))
+                  (Thread/sleep 50)
+                  42)]
+    (is (= 42 ret))
+    (is (<= 50000000 (:subop m) 60000000))
+    (is (<= 100000000 (:full m)))))
+


### PR DESCRIPTION
V1.0 brings the following changes:

* Added Clojure 1.9 and JDK9 support.
* Removed Clojure 1.5 and 1.6 support.
* Made scheduler act more deterministic when the queue is congested.
* Introduced `(status [worker])` function that returns the worker status and the size of database queues.
* Added job processing time information to logs and the new status information.
